### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Flow blockchain tools for Model Context Protocol (MCP). This package provides a set of tools for interacting with the Flow blockchain through the Model Context Protocol.
 
+<a href="https://glama.ai/mcp/servers/@Outblock/flow-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Outblock/flow-mcp/badge" alt="Flow MCP server" />
+</a>
+
 ## Features
 
 - Get FLOW balance for any address


### PR DESCRIPTION
This PR adds a badge for the [Flow MCP](https://glama.ai/mcp/servers/@Outblock/flow-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Outblock/flow-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Outblock/flow-mcp/badge" alt="Flow MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.